### PR TITLE
add .venv to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 dist/
+.venv/


### PR DESCRIPTION
This PR adds .venv to gitignore. 

Preferably, you'd use https://github.com/github/gitignore/blob/main/Python.gitignore

But this does the job. 

---

If you don't want to merge this, perhaps a temporary fix would be to add into `.git/info/exclude`, but that's not optimal. 