### PR TITLE
move pytest and pytest-asyncio to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = [
-    "pytest_asyncio",
-]
+dependencies = []
 
 [project.urls]
 Documentation = "https://github.com/jeff-dh/aio_process_pool#readme"
@@ -42,6 +40,11 @@ extra-dependencies = [
 ]
 [tool.hatch.envs.types.scripts]
 check = "mypy --install-types --non-interactive {args:src/aio_process_pool tests}"
+[tool.hatch.envs.tests]
+extra-dependencies = [
+  "pytest>=8.0.0",
+  "pytest-asyncio>=0.26.0",
+]
 
 [tool.coverage.run]
 source_pkgs = ["aio_process_pool", "tests"]


### PR DESCRIPTION
This PR move pytest and pytest-asyncio to dev dependencies. 

Otherwise, pytest-asyncio will be installed always, when you `pip install -e .` for development, and `pip install aio-process-pool` for installation. 

You need the following to run tests from this point onward: 

```
hatch env create tests
hatch shell tests
pytest
```